### PR TITLE
Fix possible fix(deps): 3 vulnerable dependencies in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 require (
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5
 	github.com/miekg/dns v1.1.72
-	golang.org/x/crypto v0.54.0
-	golang.org/x/mod v0.37.0
+	golang.org/x/crypto v0.55.0
+	golang.org/x/mod v0.40.0
 	golang.org/x/net v0.56.0
 )
 


### PR DESCRIPTION
This changes `go.mod` to address something a scan flagged. It is around line 1.

CRITICAL — CVE-2026-56854 affects golang.org/x/crypto v0.54.0 (ssh package). The server-side enforcement of the source-address critical option was incomplete: Permissions.SourceAddresses returned from PasswordCallback, KeyboardInteractiveCallback, NoClientAuthCallback, and GSSAPIWithMICConfig.AllowLogin were never validated against the client's remote address (only PublicKeyCallback/VerifiedPublicKeyCallback paths enforced it, partially fixing CVE-2026-46595). Impact: any server that relies on source-address restrictions set via those callbacks to restrict where clients may authenticate from will have those restrictions silently ignored. An attacker can connect and authenticate from any network location (e.g., from outside a restricted CIDR range), resulting in an authentication bypass of IP-based access controls. If your SSH server code sets Permissions.SourceAddresses in any of the affected callbacks, treat this as exploitable and upgrade immediately. Fixed in v0.55.0. Risk: CRITICAL.

Updates golang.org/x/crypto and golang.org/x/mod to versions with fixes for the reported critical and high CVEs.

For reference: rule `CVE-2026-56854`. Rated critical.

I do not know the codebase, so please check the change fits how the rest of it works. Happy to adjust it or close this if the reasoning is off.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
