### PR TITLE
fix(awg2): не удалять чужие ip rule при очистке multi-policy (pref 71–134)

### DIFF
--- a/internal/services/awgroute/multi_policy_linux.go
+++ b/internal/services/awgroute/multi_policy_linux.go
@@ -450,7 +450,11 @@ func (svc *Service) awgClearMultiPolicyOS() {
 		table := awgMultiTableBase + i
 		mark := awgMultiMark(i)
 		pref := awgMultiPrefBySlot(i)
-		_, _ = awgRun("while ip rule del pref " + strconv.Itoa(pref) + " 2>/dev/null; do :; done")
+		// Scope the pref-based delete to our own selector: a bare `ip rule del pref N`
+		// removes ANY rule at that priority, and 71..134 overlaps the priorities
+		// Keenetic uses for its own access-policy rules (100+), silently killing
+		// policy routing until the router reboots.
+		_, _ = awgRun("while ip rule del pref " + strconv.Itoa(pref) + " fwmark " + mark + "/" + awgMultiMarkMask + " table " + strconv.Itoa(table) + " 2>/dev/null; do :; done")
 		_, _ = awgRun("while ip rule del fwmark " + mark + "/" + awgMultiMarkMask + " table " + strconv.Itoa(table) + " 2>/dev/null; do :; done")
 		_, _ = awgRun("ip route flush table " + strconv.Itoa(table) + " 2>/dev/null")
 	}


### PR DESCRIPTION
Исправляет #12.

## Проблема

`awgClearMultiPolicyOS()` удаляет правила командой `ip rule del pref N` для `N = 71..134`. Такая команда удаляет **любое** правило с этим приоритетом, а не только наше. Keenetic ставит правила своих политик доступа на приоритеты 100+ — они попадают в диапазон и сносятся.

С v1.5.0 (коммит 0603bc2) `awgClearMultiPolicyOS()` вызывается из `awgTeardownRoutingOS()`, то есть при **каждом** старте панели через `RepairRouting()` — даже если AWG-функции не используются вовсе. Роутер эти правила сам не восстанавливает, только после перезагрузки. Ломается вся маршрутизация по политикам, включая HydraRoute Neo, который маркирует трафик в политику Keenetic.

## Правка

Удаление по `pref` дополнено нашим селектором (`fwmark mark/mask` + `table`), как в соседней строке цикла. Наши правила всегда добавляются вместе с `pref`, `fwmark` и `table` (`awgInstallMultiRoutes`), поэтому очистка своих правил не страдает, а чужие больше не задеваются.

Отдельно можно рассмотреть сдвиг `awgMultiPrefBase`, чтобы диапазон в принципе не пересекался с приоритетами Keenetic (100+) — в этот PR не включил, чтобы не осиротить правила, уже стоящие на старых приоритетах.

## Проверка

Собрать локально не смог (нет Go в окружении), правка — одна строка без новых зависимостей и переменных. Проверено на роутере (KeeneticOS 5.1.1) поведение до правки: после `S52nfqws2-strategy start` правила приоритетов 100–105 исчезают, после остановки панели и перезагрузки возвращаются.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
